### PR TITLE
Implement health check in service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN mkdir -p /tmp/solr /opt \
 COPY ./init-solr.sh /usr/local/bin
 COPY ./core-site.xml /opt/solr/server/etc/hadoop/
 
-HEALTHCHECK CMD "curl -A Healthcheck -sI localhost:8983/solr/admin/cores | grep 'HTTP/1.1 200 OK'"
-
 ENV PATH /opt/solr/bin:$PATH
 WORKDIR /opt/solr
 USER $SOLR_USER

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,13 @@ services:
         zenoss.zing.build_number: ${BUILD_ID:-none}
         zenoss.zing.build_url: ${BUILD_URL:-none}
     command: init-solr.sh solr start -f -cloud
+    healthcheck:
+      test: >-
+        curl -s -A 'healthcheck'  http://localhost:8983/solr/metric-catalog/admin/ping?wt=json \
+        | grep -q '"status":"OK"'
+    ports:
+    - 8983:8983 # solr
+    - 9983:9983 # embedded ZK
     environment:
       # ZK_HOST indicates the ZK nodes and optionally chroot
       # If not set, it indicates that embedded ZK should be used.


### PR DESCRIPTION
+ Move healthcheck from image into service.  The convention is that
  because multiple services can run from a single image, the healthcheck
  is per-service, not per-image.
+ Add port definitions for service debugging.