### PR TITLE
fix for shell errors like '[: -ne: unary operator expected'

### DIFF
--- a/init-solr.sh
+++ b/init-solr.sh
@@ -58,7 +58,7 @@ DATA_NODE_QUERY=http://hdfs-namenode:50070/jmx?qry=Hadoop:service=NameNode,name=
 log INFO "Wait for HDFS data node count > 0"
 while [ 1 ]; do
 	nodeCount=$(curl -s "$DATA_NODE_QUERY" | jq '.beans[0].NumLiveDataNodes')
-	if [ $nodeCount -ne 0 ]; then
+	if [ ! -z "$nodeCount" ] && [ $nodeCount -ne 0 ]; then
 		break
 	fi
 	sleep 3


### PR DESCRIPTION
Here's an example of the problems this PR fixes when some of the first calls to curl fail becuase the hdfs-namenode service hasn't started yet:
```
solr_1                               | 17/09/26 19:19:19 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | /usr/local/bin/init-solr.sh: line 61: [: -ne: unary operator expected
solr_1                               | 17/09/26 19:19:22 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | /usr/local/bin/init-solr.sh: line 61: [: -ne: unary operator expected
solr_1                               | 17/09/26 19:19:25 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | /usr/local/bin/init-solr.sh: line 61: [: null: integer expression expected
solr_1                               | 17/09/26 19:19:29 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:32 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:35 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:38 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:41 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:44 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:45 INFO init_solr.sh: Found HDFS data node count = 1
```
And the logs after the change:
```
solr_1                               | 17/09/26 19:19:19 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:22 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:25 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:29 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:32 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:35 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:38 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:41 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:44 INFO init_solr.sh: Wait for HDFS data node count > 0
solr_1                               | 17/09/26 19:19:45 INFO init_solr.sh: Found HDFS data node count = 1
```