### PR TITLE
Proper shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM openjdk:8u131-jre-alpine
 
-RUN apk add --no-cache bash curl lsof wget jq
+# Note that procps is needed for compatibility with how bin/solr expects ps to behave
+# (otherwise, the 'bin/solr stop' command does not work correctly).
+RUN apk add --no-cache bash curl lsof wget jq procps
 
 ARG SOLR_USER=solr
 ARG SOLR_UID=8983
@@ -19,6 +21,7 @@ RUN mkdir -p /tmp/solr /opt \
     && rm -rf /tmp/solr
 
 COPY ./init-solr.sh /usr/local/bin
+COPY ./start-solr.sh /usr/local/bin
 COPY ./core-site.xml /opt/solr/server/etc/hadoop/
 
 ENV PATH /opt/solr/bin:$PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         zenoss.zing.branch_name: ${GIT_BRANCH:-none}
         zenoss.zing.build_number: ${BUILD_ID:-none}
         zenoss.zing.build_url: ${BUILD_URL:-none}
-    command: init-solr.sh solr start -f -cloud
+    command: init-solr.sh start-solr.sh -verbose -f -cloud
     healthcheck:
       test: >-
         curl -s -A 'healthcheck'  http://localhost:8983/solr/metric-catalog/admin/ping?wt=json \

--- a/init-solr.sh
+++ b/init-solr.sh
@@ -57,7 +57,7 @@ init_collection () {
 DATA_NODE_QUERY=http://hdfs-namenode:50070/jmx?qry=Hadoop:service=NameNode,name=FSNamesystemState
 log INFO "Wait for HDFS data node count > 0"
 while [ 1 ]; do
-	nodeCount=$(curl -s "$DATA_NODE_QUERY" | jq '.beans[0].NumLiveDataNodes')
+	nodeCount=$(curl -s "$DATA_NODE_QUERY" | jq '.beans[0].NumLiveDataNodes | select(.!=null)')
 	if [ ! -z "$nodeCount" ] && [ $nodeCount -ne 0 ]; then
 		break
 	fi
@@ -99,4 +99,3 @@ fi
 
 # Start solr
 exec "$@"
-

--- a/start-solr.sh
+++ b/start-solr.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# This script is used to start Solr in a docker contaienr such that on receipt of
+# SIGTERM the proper "solr stop" command is invoked to insure a clean shutdown of Solr
+#
+# TODO: we should try integrating this script with an 'official' docker image for solr
+#       rather than our hand-rolled image
+#
+log () {
+    echo $(date "+%y/%m/%d %H:%M:%S") "$1 $(basename $0): $2"
+}
+
+exitHandler() {
+	log INFO "SIGTERM received; stopping solr ..."
+	solr stop
+}
+
+# Register a signal handler that will initiate the proper shutdown
+trap exitHandler SIGTERM
+
+log INFO "Starting solr with the command 'solr start $*' "
+solr start $* &
+
+# The first wait returns when SIGTERM is received
+wait
+
+# The second wait returns when the solr child process has actually exited
+wait
+RC=$?
+
+log INFO "Child exited"
+exit $?


### PR DESCRIPTION
The standard `bin/solr` script has a `stop` option which sends a command to a specific port and waits up to 3 minutes for Solr to stop, so that it has a chance to properly close all files.  Apparently, sending a SIGTERM to the Java process is not guaranteed to achieve the same end. 

This PR adds our own `start-solr.sh` script which traps SIGTERM and issues a `solr stop` command.